### PR TITLE
Support arbitrary byte sequence containers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ documentation = "https://docs.rs/iso7816"
 
 [dependencies]
 delog = "0.1.2"
-heapless = "0.7"
+# use unreleased heapless for https://github.com/japaric/heapless/pull/255
+heapless = { git = "https://github.com/japaric/heapless" }
 
 [dev-dependencies]
 hex-literal = "0.3.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,12 +10,12 @@ pub enum Interface {
     Contactless,
 }
 
-pub type Data<const S: usize> = heapless::Vec<u8, S>;
 pub type Result<T=()> = core::result::Result<T, Status>;
 
 pub mod aid;
 pub mod command;
 pub mod response;
+pub mod somebytes;
 
 pub use aid::{Aid, App};
 pub use command::{Command, Instruction};

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,15 +1,15 @@
 mod status;
 pub use status::Status;
 
-use crate::Data;
+use crate::somebytes::Bytes;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub enum Response<const S: usize> {
-    Data(Data<S>),
+pub enum Response<B: AsRef<[u8]>> {
+    Data(Bytes<B>),
     Status(Status),
 }
 
-impl<const S: usize> Default for Response<S> {
+impl<B: AsRef<[u8]>> Default for Response<B> {
     fn default() -> Self {
         Self::Status(Default::default())
     }

--- a/src/response/status.rs
+++ b/src/response/status.rs
@@ -1,5 +1,4 @@
 use core::convert::TryFrom;
-use crate::Data;
 
 impl Default for Status {
     fn default() -> Self {
@@ -171,12 +170,10 @@ impl Into<[u8; 2]> for Status {
     }
 }
 
-impl<const S: usize> Into<Data<S>> for Status
-{
+impl<const S: usize> Into<heapless::Vec<u8, S>> for Status {
     #[inline]
-    fn into(self) -> Data<S> {
+    fn into(self) -> heapless::Vec<u8, S> {
         let arr: [u8; 2] = self.into();
-        Data::from_slice(&arr).unwrap()
+        heapless::Vec::from_slice(&arr).unwrap()
     }
 }
-

--- a/src/somebytes.rs
+++ b/src/somebytes.rs
@@ -1,0 +1,79 @@
+// This could be a separate crate.
+
+use core::{cmp, fmt, ops};
+
+pub trait TryExtendFromSlice<T> {
+    type Error;
+    fn extend_from_slice(&mut self, slice: &[T]) -> Result<(), Self::Error>;
+}
+
+impl<T: Clone, const N: usize> TryExtendFromSlice<T> for heapless::Vec<T, N> {
+    type Error = ();
+    fn extend_from_slice(&mut self, slice: &[T]) -> Result<(), Self::Error> {
+        heapless::Vec::extend_from_slice(self, slice)
+    }
+}
+
+/// A wrapper type for a byte sequence.
+///
+/// This wrapper implements common traits based on the content of the byte sequence.
+#[derive(Clone)]
+pub struct Bytes<T: AsRef<[u8]>>(T);
+
+impl<T: AsRef<[u8]>> Bytes<T> {
+    pub fn into_bytes(self) -> T {
+        self.0
+    }
+}
+
+impl<T: AsRef<[u8]>> AsRef<[u8]> for Bytes<T> {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+impl<T: AsRef<[u8]>> ops::Deref for Bytes<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T: AsRef<[u8]>> ops::DerefMut for Bytes<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<T: AsRef<[u8]>> From<T> for Bytes<T> {
+    fn from(bytes: T) -> Self {
+        Self(bytes)
+    }
+}
+
+impl<T: AsRef<[u8]>> fmt::Debug for Bytes<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.as_ref().fmt(f)
+    }
+}
+
+impl<T: AsRef<[u8]>> Eq for Bytes<T> {}
+
+impl<T: AsRef<[u8]>> PartialEq for Bytes<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.as_ref().eq(other.0.as_ref())
+    }
+}
+
+impl<T: AsRef<[u8]>> Ord for Bytes<T> {
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        self.0.as_ref().cmp(other.0.as_ref())
+    }
+}
+
+impl<T: AsRef<[u8]>> PartialOrd for Bytes<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        self.0.as_ref().partial_cmp(other.0.as_ref())
+    }
+}


### PR DESCRIPTION
Previously, the Command and Response types always used `heapless::Vec` to store the payload.  This was awkward to use in non-embedded environments where `std::vec::Vec` might be preferable, or in situations where a slice is sufficient.

This patch relaxes this requirement and accepts any type implementing `AsRef<[u8]>` (and `TryFrom<&[u8]>` for construction).