### PR TITLE
Fix panic in parse lengths when 2 bytes of data start with 0x00

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -271,7 +271,9 @@ fn parse_lengths(body: &[u8]) -> Result<ParsedLengths, FromSliceError> {
     // only extended cases left now
     if b1 != 0 {
         return Err(FromSliceError::InvalidFirstBodyByteForExtended);
-    };
+    } else if l < 3 {
+        return Err(FromSliceError::InvalidSliceLength);
+    }
 
     // Case 2E (no data)
     if l == 3 && b1 == 0 {
@@ -309,6 +311,7 @@ fn parse_lengths(body: &[u8]) -> Result<ParsedLengths, FromSliceError> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use hex_literal::hex;
 
     #[test]
     fn command_chaining() {
@@ -335,5 +338,13 @@ mod test {
         ];
 
         let _command = Command::<256>::try_from(apdu).unwrap();
+    }
+
+    #[test]
+    fn lc_oob() {
+        let apdu = &hex!("00C00000 00FF");
+        let _ = Command::<256>::try_from(apdu);
+        let apdu = &hex!("00C00000 0000");
+        let _ = Command::<256>::try_from(apdu);
     }
 }


### PR DESCRIPTION
The `parse_length` method panicked when the input data was `00 XX`. The `00` made the parser assume the length was encoded extended but didn't check that there was enough data for that. This PR rejects such inputs and adds a test case for it.